### PR TITLE
Revert "Bump kotlin_version from 1.4.32 to 1.5.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.4.32'
     ext.dagger_version = '2.35'
 
     repositories {


### PR DESCRIPTION
Reverts alejandrorosas/android-uvc-rtmp-stream#14 that is causing https://github.com/alejandrorosas/android-uvc-rtmp-stream/issues/16

```
java.lang.NoSuchMethodError: No static method metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite; in class Ljava/lang/invoke/LambdaMetafactory; or its super classes (declaration of 'java.lang.invoke.LambdaMetafactory' appears in /apex/com.android.runtime/javalib/core-oj.jar)
        at dev.alejandrorosas.apptemplate.MainActivity.onCreate(MainActivity.kt:35)
```